### PR TITLE
Strict matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: no_comma
 
+Style/SignalException:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   Enabled: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ Initial implementation.
 Proposal added.
 
 [@palkan]: https://github.com/palkan
+[@Earendil95]: https://github.com/Earendil95

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `fail_when_no_matches` parameter to `match` method. ([@Earendil95][])
+
 ## 0.1.3 (2019-03-05)
 
 - Fix using `activate_always: true` with `default` matching clause. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ class CourseSessionsPlane < Rubanok::Plane
 end
 ```
 
-By default, Rubanok will not fail if no matches found in `match` rule. You can change it by setting: `Rubanok.fail_when_no_matches = true`
+By default, Rubanok will not fail if no matches found in `match` rule. You can change it by setting: `Rubanok.fail_when_no_matches = true`.
+If in example above you will call `CourseSessionsPlane.call(CourseSession, filter: 'acitve')`, you will get `Rubanok::UnexpectedInputError: Unexpected input: {:filter=>'acitve'}`
 
 **NOTE:** Rubanok only matches exact values; more complex matching could be added in the future.
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ class CourseSessionsPlane < Rubanok::Plane
       raw.order(sort_by => sort)
     end
   end
+
+  # strict matching; if Plane will not match parameter, it will raise Rubanok::BadValueError
+  # You can handle it in controller, for example, with sending 400 to client
+  match :filter, fail_when_no_matches: true do
+    having "active" do
+      raw.active
+    end
+
+    having "finished" do
+      raw.finished
+    end
+  end
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ class CourseSessionsPlane < Rubanok::Plane
     end
   end
 
-  # strict matching; if Plane will not match parameter, it will raise Rubanok::BadValueError
-  # You can handle it in controller, for example, with sending 400 to client
+  # strict matching; if Plane will not match parameter, it will raise Rubanok::UnexpectedInputError
+  # You can handle it in controller, for example, with sending 422 Unprocessable Entity to client
   match :filter, fail_when_no_matches: true do
     having "active" do
       raw.active
@@ -148,7 +148,7 @@ end
 ```
 
 By default, Rubanok will not fail if no matches found in `match` rule. You can change it by setting: `Rubanok.fail_when_no_matches = true`.
-If in example above you will call `CourseSessionsPlane.call(CourseSession, filter: 'acitve')`, you will get `Rubanok::UnexpectedInputError: Unexpected input: {:filter=>'acitve'}`
+If in example above you will call `CourseSessionsPlane.call(CourseSession, filter: 'acitve')`, you will get `Rubanok::UnexpectedInputError: Unexpected input: {:filter=>'acitve'}`.
 
 **NOTE:** Rubanok only matches exact values; more complex matching could be added in the future.
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ class CourseSessionsPlane < Rubanok::Plane
 end
 ```
 
+By default, Rubanok will not fail if no matches found in `match` rule. You can change it by setting: `Rubanok.fail_when_no_matches = true`
+
 **NOTE:** Rubanok only matches exact values; more complex matching could be added in the future.
 
 ### Rule activation

--- a/lib/rubanok.rb
+++ b/lib/rubanok.rb
@@ -16,7 +16,7 @@ end
 #
 #   class CourseSessionPlane < Rubanok::Plane
 #     map :q do |q:|
-#      raw.searh(q)
+#       raw.searh(q)
 #     end
 #   end
 #
@@ -31,7 +31,10 @@ module Rubanok
     # When the value is empty and ignored the corresponding matcher/mapper
     # is not activated (true by default)
     attr_accessor :ignore_empty_values
+    # Define wheter to fail when `match` rule cannot find matching value
+    attr_accessor :fail_when_no_matches
   end
 
   self.ignore_empty_values = true
+  self.fail_when_no_matches = false
 end

--- a/lib/rubanok.rb
+++ b/lib/rubanok.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rubanok/version"
-require "rubanok/bad_value_error"
 require "rubanok/plane"
 
 require "rubanok/railtie" if defined?(Rails)

--- a/lib/rubanok.rb
+++ b/lib/rubanok.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rubanok/version"
+require "rubanok/bad_value_error"
 require "rubanok/plane"
 
 require "rubanok/railtie" if defined?(Rails)

--- a/lib/rubanok/bad_value_error.rb
+++ b/lib/rubanok/bad_value_error.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Rubanok
-  class BadValueError < StandardError; end
-end

--- a/lib/rubanok/bad_value_error.rb
+++ b/lib/rubanok/bad_value_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Rubanok
+  class BadValueError < StandardError; end
+end

--- a/lib/rubanok/dsl/mapping.rb
+++ b/lib/rubanok/dsl/mapping.rb
@@ -31,7 +31,7 @@ module Rubanok
       end
 
       def self.included(base)
-        base.extend(ClassMethods)
+        base.extend ClassMethods
       end
     end
   end

--- a/lib/rubanok/dsl/mapping.rb
+++ b/lib/rubanok/dsl/mapping.rb
@@ -20,12 +20,18 @@ module Rubanok
         end
       end
 
-      def map(*fields, **options, &block)
-        rule = Rule.new(fields, options)
+      module ClassMethods
+        def map(*fields, **options, &block)
+          rule = Rule.new(fields, options)
 
-        define_method(rule.to_method_name, &block)
+          define_method(rule.to_method_name, &block)
 
-        rules << rule
+          rules << rule
+        end
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
       end
     end
   end

--- a/lib/rubanok/dsl/matching.rb
+++ b/lib/rubanok/dsl/matching.rb
@@ -65,7 +65,8 @@ module Rubanok
       end
 
       module InstanceMethods
-        def default_match_handler(rule, params, fail_when_no_matches = false)
+        def default_match_handler(rule, params, fail_when_no_matches)
+          fail_when_no_matches ||= Rubanok.fail_when_no_matches
           return raw unless fail_when_no_matches
 
           fail ::Rubanok::BadValueError, <<~MSG

--- a/lib/rubanok/dsl/matching.rb
+++ b/lib/rubanok/dsl/matching.rb
@@ -95,7 +95,11 @@ module Rubanok
         fail_when_no_matches = Rubanok.fail_when_no_matches if fail_when_no_matches.nil?
         return raw unless fail_when_no_matches
 
-        raise ::Rubanok::UnexpectedInputError, "Unexpected input: #{params.slice(*rule.fields)}"
+        raise ::Rubanok::UnexpectedInputError, <<~MSG
+          Unexpected input: #{params.slice(*rule.fields)}.
+          Available values are:
+            #{rule.clauses.map(&:values).join("\n  ")}
+        MSG
       end
     end
   end

--- a/lib/rubanok/dsl/matching.rb
+++ b/lib/rubanok/dsl/matching.rb
@@ -66,7 +66,7 @@ module Rubanok
 
       module InstanceMethods
         def default_match_handler(rule, params, fail_when_no_matches)
-          fail_when_no_matches ||= Rubanok.fail_when_no_matches
+          fail_when_no_matches = Rubanok.fail_when_no_matches if fail_when_no_matches.nil?
           return raw unless fail_when_no_matches
 
           fail ::Rubanok::BadValueError, <<~MSG

--- a/lib/rubanok/plane.rb
+++ b/lib/rubanok/plane.rb
@@ -31,10 +31,9 @@ module Rubanok
   # You can access the input data via `raw` method.
   class Plane
     extend DSL::Matching
+    extend DSL::Mapping
 
     class << self
-      include DSL::Mapping
-
       def call(input, params)
         new(input).call(params)
       end

--- a/lib/rubanok/plane.rb
+++ b/lib/rubanok/plane.rb
@@ -31,9 +31,10 @@ module Rubanok
   # You can access the input data via `raw` method.
   class Plane
     extend DSL::Matching
-    extend DSL::Mapping
 
     class << self
+      include DSL::Mapping
+
       def call(input, params)
         new(input).call(params)
       end

--- a/lib/rubanok/plane.rb
+++ b/lib/rubanok/plane.rb
@@ -30,9 +30,10 @@ module Rubanok
   #
   # You can access the input data via `raw` method.
   class Plane
+    extend DSL::Matching
+
     class << self
       include DSL::Mapping
-      include DSL::Matching
 
       def call(input, params)
         new(input).call(params)

--- a/lib/rubanok/plane.rb
+++ b/lib/rubanok/plane.rb
@@ -30,11 +30,10 @@ module Rubanok
   #
   # You can access the input data via `raw` method.
   class Plane
-    extend DSL::Matching
+    include DSL::Matching
+    include DSL::Mapping
 
     class << self
-      include DSL::Mapping
-
       def call(input, params)
         new(input).call(params)
       end

--- a/lib/rubanok/rails/controller.rb
+++ b/lib/rubanok/rails/controller.rb
@@ -9,14 +9,14 @@ module Rubanok
     extend ActiveSupport::Concern
 
     # Planish passed data (e.g. ActiveRecord relation) using
-    # the corrsponding Plane class.
+    # the corresponding Plane class.
     #
     # Plane is inferred from controller name, e.g.
     # "PostsController -> PostPlane".
     #
     # You can specify the Plane class explicitly via `with` option.
     #
-    # By default, `params` object is passed as paraters, but you
+    # By default, `params` object is passed as parameters, but you
     # can specify the params via `params` option.
     def planish(data, plane_params = nil, with: implicit_plane_class)
       if with.nil?

--- a/spec/cases/matching_spec.rb
+++ b/spec/cases/matching_spec.rb
@@ -129,6 +129,36 @@ describe "Plane.match" do
         expect { subject }.to raise_error(Rubanok::BadValueError)
       end
     end
+
+    context "Rubanok.fail_when_no_matches" do
+      let(:plane) do
+        Class.new(Rubanok::Plane) do
+          match :status do
+            having "past" do
+              raw.select { |item| item[:status] == "past" }
+            end
+          end
+        end
+      end
+
+      let(:params) { Hash[status: "unknown"] }
+
+      around do |ex|
+        was_value = Rubanok.fail_when_no_matches
+        ex.run
+        Rubanok.fail_when_no_matches = was_value
+      end
+
+      specify "true" do
+        Rubanok.fail_when_no_matches = true
+        expect { subject }.to raise_error(Rubanok::BadValueError)
+      end
+
+      specify "false" do
+        Rubanok.fail_when_no_matches = false
+        expect(subject).to eq(input)
+      end
+    end
   end
 
   context "multiple fields" do

--- a/spec/cases/matching_spec.rb
+++ b/spec/cases/matching_spec.rb
@@ -126,7 +126,7 @@ describe "Plane.match" do
 
       specify "when no matching value" do
         params["status"] = "unknown"
-        expect { subject }.to raise_error(Rubanok::BadValueError)
+        expect { subject }.to raise_error(Rubanok::UnexpectedInputError)
       end
     end
 
@@ -151,7 +151,7 @@ describe "Plane.match" do
 
       specify "true" do
         Rubanok.fail_when_no_matches = true
-        expect { subject }.to raise_error(Rubanok::BadValueError)
+        expect { subject }.to raise_error(Rubanok::UnexpectedInputError)
       end
 
       specify "false" do

--- a/spec/cases/matching_spec.rb
+++ b/spec/cases/matching_spec.rb
@@ -112,6 +112,23 @@ describe "Plane.match" do
         expect(subject.size).to eq 3
       end
     end
+
+    context "with fail_when_no_matches" do
+      let(:plane) do
+        Class.new(Rubanok::Plane) do
+          match :status, fail_when_no_matches: true do
+            having "past" do
+              raw.select { |item| item[:status] == "past" }
+            end
+          end
+        end
+      end
+
+      specify "when no matching value" do
+        params["status"] = "unknown"
+        expect { subject }.to raise_error(Rubanok::BadValueError)
+      end
+    end
   end
 
   context "multiple fields" do

--- a/spec/cases/matching_spec.rb
+++ b/spec/cases/matching_spec.rb
@@ -159,6 +159,29 @@ describe "Plane.match" do
         expect(subject).to eq(input)
       end
     end
+
+    context "when Rubanok.fail_when_no_matches = true and explicitly passed false" do
+      let(:plane) do
+        Class.new(Rubanok::Plane) do
+          match :status, fail_when_no_matches: false do
+            having "past" do
+              raw.select { |item| item[:status] == "past" }
+            end
+          end
+        end
+      end
+
+      around do |ex|
+        was_value = Rubanok.fail_when_no_matches
+        Rubanok.fail_when_no_matches = true
+        ex.run
+        Rubanok.fail_when_no_matches = was_value
+      end
+
+      it "does not fail" do
+        expect(subject).to eq(input)
+      end
+    end
   end
 
   context "multiple fields" do


### PR DESCRIPTION
Hi, Vladimir!

### Problem

Now, for `match` rules default is returning `raw`, if we did not specify `default` block. This means that if someone makes a mistake or typo, no one will know about it or we need to add in each Plane something like this:

```ruby
class MyPlane < Rubanok::Plane
  match :filter do
    having "current" do
      raw.current
    end

    having "planned" do
      raw.planned
    end

    default do |*|
      fail "Bad value for filter"
    end
  end
end
```

### Solution

I have added `fail_when_no_matches` option to `match` and `Rubanok.fail_when_no_matches` variable to setup default behavior.

### P.S.

I also fixed some typos in documentation :)  