### PR TITLE
Add ability to scope params without applying rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,32 @@
 
 ## master
 
+- Add `Process.project` and `rubanok_scope` methods to get the Hash of recognized params. ([@palkan][])
+
+```ruby
+class PostsProcessor < Rubanok::Processor
+  map :q { ... }
+  match :page, :per_page, activate_on: :page { ... }
+end
+
+PostsProcessor.project(q: "search_me", filter: "smth", page: 2)
+# => { q: "search_me", page: 2 }
+
+class PostsController < ApplicationController
+  def index
+    @filter_params = rubanok_scope
+    # or
+    @filter_params = rubanok_scope params.require(:filter), with: PostsProcessor
+    # ...
+  end
+end
+```
+
 - Improve naming by using "processor" instead of "plane". ([@palkan][])
 
-  See [the discussion](https://github.com/palkan/rubanok/issues/3).
+See [the discussion](https://github.com/palkan/rubanok/issues/3).
 
-  **NOTE**: Older API is still available without deprecation.
+**NOTE**: Older API is still available without deprecation.
 
 - Add `fail_when_no_matches` parameter to `match` method. ([@Earendil95][])
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,34 @@ If in example above you will call `CourseSessionsProcessor.call(CourseSession, f
 
 **NOTE:** Rubanok only matches exact values; more complex matching could be added in the future.
 
+### Getting the matching params
+
+Sometimes it could be useful to get the params that were used to process the data by Rubanok processor (e.g., you can use this data in views to display the actual filters state).
+
+In Rails, you can use the `#rubanok_scope` method for that:
+
+```ruby
+class CourseSessionController < ApplicationController
+  def index
+    @sessions = rubanok_process(CourseSession.all)
+    # Returns the Hash of params recognized by the CourseSessionProcessor.
+    # For example:
+    #
+    #    params == {q: "search", role_id: 2, date: "2019-08-22"}
+    #    @session_filter == {q: "search", role_id: 2}
+    @sessions_filter = rubanok_scope(
+      params.permit(:q, :role_id),
+      with: CourseSessionProcessor
+    )
+
+    # You can omit all the arguments
+    @sessions_filter = rubanok_scope #=> equals to rubanok_scope(params, with: implicit_rubanok_class)
+  end
+end
+```
+
+You can also accesss `rubanok_scope` in views (it's a helper method).
+
 ### Rule activation
 
 Rubanok _activates_ a rule by checking whether the corresponding keys are present in the params object. All the fields must be present to apply the rule.

--- a/lib/rubanok/dsl/mapping.rb
+++ b/lib/rubanok/dsl/mapping.rb
@@ -26,7 +26,7 @@ module Rubanok
 
           define_method(rule.to_method_name, &block)
 
-          rules << rule
+          add_rule rule
         end
       end
 

--- a/lib/rubanok/dsl/matching.rb
+++ b/lib/rubanok/dsl/matching.rb
@@ -83,7 +83,7 @@ module Rubanok
             define_method(clause.to_method_name, &clause.block)
           end
 
-          rules << rule
+          add_rule rule
         end
       end
 

--- a/lib/rubanok/processor.rb
+++ b/lib/rubanok/processor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 require "rubanok/rule"
 
 require "rubanok/dsl/mapping"
@@ -39,6 +41,7 @@ module Rubanok
       end
 
       def add_rule(rule)
+        fields_set.merge rule.fields
         rules << rule
       end
 
@@ -51,6 +54,23 @@ module Rubanok
           else
             []
           end
+      end
+
+      def fields_set
+        return @fields_set if instance_variable_defined?(:@fields_set)
+
+        @fields_set =
+          if superclass <= Processor
+            superclass.fields_set.dup
+          else
+            Set.new
+          end
+      end
+
+      # Generates a `params` projection including only the keys used
+      # by the rules
+      def project(params)
+        params.slice(*fields_set)
       end
     end
 

--- a/lib/rubanok/processor.rb
+++ b/lib/rubanok/processor.rb
@@ -70,6 +70,7 @@ module Rubanok
       # Generates a `params` projection including only the keys used
       # by the rules
       def project(params)
+        params = params.symbolize_keys
         params.slice(*fields_set)
       end
     end

--- a/lib/rubanok/rails/controller.rb
+++ b/lib/rubanok/rails/controller.rb
@@ -8,7 +8,12 @@ module Rubanok
   module Controller
     extend ActiveSupport::Concern
 
-    # This method passed data (e.g. ActiveRecord relation) using
+    included do
+      helper_method :rubanok_scope
+      helper_method :planish_scope
+    end
+
+    # This method process passed data (e.g. ActiveRecord relation) using
     # the corresponding Processor class.
     #
     # Processor is inferred from controller name, e.g.
@@ -18,25 +23,55 @@ module Rubanok
     #
     # By default, `params` object is passed as parameters, but you
     # can specify the params via `params` option.
-    def rubanok_process(data, plane_params = nil, with: implicit_rubanok_class)
-      if with.nil?
-        raise ArgumentError, "Failed to find a processor class for #{self.class.name}. " \
-                             "Please, specify the processor class explicitly via `with` option"
+    def rubanok_process(data, params = nil, with: nil)
+      with_inferred_rubanok_params(with, params) do |rubanok_class, rubanok_params|
+        rubanok_class.call(data, rubanok_params)
       end
-
-      plane_params ||= params
-
-      plane_params = plane_params.to_unsafe_h if plane_params.is_a?(ActionController::Parameters)
-      with.call(data, plane_params)
     end
 
-    def planish(*args, with: implicit_plane_class)
-      rubanok_process(*args, with: with)
+    # This method filters the passed params and returns the Hash (!)
+    # of the params recongnized by the processor.
+    #
+    # Processor is inferred from controller name, e.g.
+    # "PostsController -> PostProcessor".
+    #
+    # You can specify the Processor class explicitly via `with` option.
+    #
+    # By default, `params` object is passed as parameters, but you
+    # can specify the params via `params` option.
+    def rubanok_scope(params = nil, with: nil)
+      with_inferred_rubanok_params(with, params) do |rubanok_class, rubanok_params|
+        rubanok_class.project(rubanok_params)
+      end
     end
 
     # Tries to infer the rubanok processor class from controller path
     def implicit_rubanok_class
       "#{controller_path.classify.pluralize}Processor".safe_constantize
+    end
+
+    def with_inferred_rubanok_params(with, params)
+      with ||= implicit_rubanok_class
+
+      if with.nil?
+        raise ArgumentError, "Failed to find a processor class for #{self.class.name}. " \
+                             "Please, specify the processor class explicitly via `with` option"
+      end
+
+      params ||= self.params
+
+      params = params.to_unsafe_h if params.is_a?(ActionController::Parameters)
+
+      yield with, params
+    end
+
+    # Backward compatibility
+    def planish(*args, with: implicit_plane_class)
+      rubanok_process(*args, with: with)
+    end
+
+    def planish_scope(*args, with: implicit_plane_class)
+      rubanok_scope(*args, with: with)
     end
 
     def implicit_plane_class

--- a/spec/integrations/rails_controller_spec.rb
+++ b/spec/integrations/rails_controller_spec.rb
@@ -12,6 +12,16 @@ class PostsPlane < Rubanok::Plane
   map :type do |type:|
     raw.select { |item| item[:type] == type }
   end
+
+  match :sort_by, :sort, activate_on: :sort_by do
+    having "type" do |sort: "asc"|
+      coef = sort == "asc" ? 1 : -1
+      raw.sort do |a, b|
+        next 0 if a[:type] == b[:type]
+        coef * (a[:type] == "sports" ? -1 : 1)
+      end
+    end
+  end
 end
 
 PostsProcessor = PostsPlane
@@ -71,6 +81,14 @@ class PostsController < ActionController::Base
     data = rubanok_process(FAKE_DATA)
     render json: data
   end
+
+  def scoped
+    render json: rubanok_scope(params.permit(:type, :sort, :sort_by, :date))
+  end
+
+  def scoped_plane
+    render json: planish_scope
+  end
 end
 
 describe PostsController do
@@ -92,6 +110,13 @@ describe PostsController do
       expect(data.size).to eq 2
     end
 
+    specify "implicit rubanok with matching" do
+      get :implicit, {sort_by: "type", sort: "desc"}.to_params
+
+      expect(data.size).to eq 3
+      expect(data.first["type"]).to eq "lifestyle"
+    end
+
     specify "implicit plane" do
       get :implicit_plane, {type: "sports"}.to_params
 
@@ -103,6 +128,28 @@ describe PostsController do
 
       expect(data.size).to eq 1
       expect(data.first["id"]).to eq 25
+    end
+
+    specify "#rubanok_scope" do
+      get :scoped, {type: "sports", date: "2019-08-22", sort_by: "id", sort: "desc", one_more: "key"}.to_params
+
+      expect(data).to eq(
+        {
+          "type" => "sports",
+          "sort_by" => "id",
+          "sort" => "desc"
+        }
+      )
+    end
+
+    specify "#planish_scope" do
+      get :scoped_plane, {date: "2019-08-22", sort_by: "id", one_more: "key"}.to_params
+
+      expect(data).to eq(
+        {
+          "sort_by" => "id"
+        }
+      )
     end
   end
 end

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe Rubanok::Processor do
+  describe ".project" do
+    let(:processor) do
+      Class.new(Rubanok::Processor) do
+        map :q do |q:|
+          raw
+        end
+
+        match :sort_by, :sort, activate_on: :sort_by do
+          having "status", "asc" do
+            raw
+          end
+
+          default do |sort_by:, sort: "asc"|
+            raw
+          end
+        end
+      end
+    end
+
+    it "returns only processable params" do
+      expect(
+        processor.project(a: "x", filter: "active", q: "daaron", sort_by: "id", sort: "desc")
+      ).to eq(
+        {
+          q: "daaron",
+          sort_by: "id",
+          sort: "desc"
+        }
+      )
+    end
+
+    it "doesn't return keys not present in params" do
+      expect(
+        processor.project(a: "x", sort_by: "id", sort: "desc")
+      ).to eq(
+        {
+          sort_by: "id",
+          sort: "desc"
+        }
+      )
+    end
+
+    it "doesn't return defaults" do
+      expect(processor.project(sort_by: "name")).to eq(
+        {
+          sort_by: "name"
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
- [x] Add `Processor.project`

This method filters the passed params and leaves only those recognized by the processor:

```ruby
class MyProcessor < Rubanok::Processor
  map :q { ... }
  match :page, :per_page, activate_on: :page { ... }
end

MyProcessor.project(q: "search_me", filter: "smth", page: 2)
# => { q: "search_me", page: 2 }
```

- [x] Add `rubanok_scope` helper for Rails controllers (Closes #4).
