### PR TITLE
Fix errors caused by `rake steep` and `rake spec` commands related to deprecated methods and argument issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix errors caused by `rake steep` and `rake spec` commands related to deprecated methods and argument issues. ([@mizoR][])
+
 ## 0.5.0 (2023-12-04)
 
 - Add nested processors support. ([@palkan][])

--- a/lib/rubanok/processor.rb
+++ b/lib/rubanok/processor.rb
@@ -123,7 +123,7 @@ module Rubanok
         if data.empty?
           send(method_name)
         else
-          send(method_name, **data)
+          send(method_name, **data.transform_keys(&:to_sym))
         end
     end
 

--- a/spec/integrations/controller_helper.rb
+++ b/spec/integrations/controller_helper.rb
@@ -20,7 +20,7 @@ end
 SharedTestRoutes = ActionDispatch::Routing::RouteSet.new
 
 SharedTestRoutes.draw do
-  ActiveSupport::Deprecation.silence do
+  ActiveSupport::Deprecation.new.silence do
     get ":controller(/:action)"
   end
 end


### PR DESCRIPTION
Hi there!

I really like the design of the Filter object in "Layered Design for Ruby on Rails Applications." Thank you for creating and maintaining this gem!

## What is the purpose of this pull request?

This pull request addresses two issues that occur when running bundle exec rake:

1. ActiveSupport::Deprecation#silence has been deprecated due to a Rails version upgrade.
```
An error occurred while loading ./spec/integrations/rails_controller_spec.rb.
Failure/Error:
  ActiveSupport::Deprecation.silence do
    get ":controller(/:action)"
  end

NoMethodError:
  undefined method `silence' for class ActiveSupport::Deprecation
# ./spec/integrations/controller_helper.rb:23:in `block in <top (required)>'
# ./.bundle/bundle/ruby/3.3.0/gems/actionpack-8.0.0/lib/action_dispatch/routing/route_set.rb:479:in `instance_exec'
# ./.bundle/bundle/ruby/3.3.0/gems/actionpack-8.0.0/lib/action_dispatch/routing/route_set.rb:479:in `eval_block'
# ./.bundle/bundle/ruby/3.3.0/gems/actionpack-8.0.0/lib/action_dispatch/routing/route_set.rb:461:in `draw'
# ./spec/integrations/controller_helper.rb:22:in `<top (required)>'
# ./spec/integrations/rails_controller_spec.rb:3:in `require_relative'
# ./spec/integrations/rails_controller_spec.rb:3:in `<top (required)>'
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Finished in 0.00007 seconds (files took 3.64 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```
2. The send method is given a Hash with string keys as optional arguments.
```
lib/rubanok/processor.rb:126:30: [error] Cannot pass a value of type `::Hash[(::Symbol | ::String), untyped]` as an argument of type `::Hash[::Symbol, untyped]`
│   ::Hash[(::Symbol | ::String), untyped] <: ::Hash[::Symbol, untyped]
│     (::Symbol | ::String) <: ::Symbol
│       ::String <: ::Symbol
│         ::Object <: ::Symbol
│           ::BasicObject <: ::Symbol
│
│ Diagnostic ID: Ruby::ArgumentTypeMismatch
│
└           send(method_name, **data)
                                ~~~~
```

These changes ensure that Rake tasks can run without errors.

## What changes did you make? (overview)

- Replaced usages of ActiveSupport::Deprecation#silence with `ActiveSupport::Deprecation.new.silence`.
- Updated the Hash passed to the send method to use symbol keys instead of string keys.

## Is there anything you'd like reviewers to focus on?

Nothing specific. Please feel free to review the changes as a whole.

## Checklist

- [x] I've added tests for this change
  - I confirmed that `bundle exec rake` passed
- [x] I've added a Changelog entry
- [x] I've updated a documentation
  - Just bug fixed. No changes for the documentation.
